### PR TITLE
Bugfix - move all javelins to 2-tick

### DIFF
--- a/src/main/java/com/github/calebwhiting/runelite/data/Fletching.java
+++ b/src/main/java/com/github/calebwhiting/runelite/data/Fletching.java
@@ -1,5 +1,7 @@
 package com.github.calebwhiting.runelite.data;
 
+import static net.runelite.api.ItemID.MITHRIL_JAVELIN;
+
 import net.runelite.api.ItemID;
 
 public interface Fletching
@@ -34,7 +36,7 @@ public interface Fletching
 	};
 
 	int[] JAVELINS = {
-			ItemID.BRONZE_JAVELIN, ItemID.STEEL_JAVELIN, ItemID.ADAMANT_JAVELIN, ItemID.RUNE_JAVELIN,
-			ItemID.AMETHYST_JAVELIN, ItemID.DRAGON_JAVELIN
+			ItemID.BRONZE_JAVELIN, ItemID.IRON_JAVELIN, ItemID.STEEL_JAVELIN, ItemID.MITHRIL_JAVELIN, 
+			ItemID.ADAMANT_JAVELIN, ItemID.RUNE_JAVELIN, ItemID.AMETHYST_JAVELIN, ItemID.DRAGON_JAVELIN,
 	};
 }

--- a/src/main/java/com/github/calebwhiting/runelite/data/Fletching.java
+++ b/src/main/java/com/github/calebwhiting/runelite/data/Fletching.java
@@ -1,7 +1,5 @@
 package com.github.calebwhiting.runelite.data;
 
-import static net.runelite.api.ItemID.MITHRIL_JAVELIN;
-
 import net.runelite.api.ItemID;
 
 public interface Fletching

--- a/src/main/java/com/github/calebwhiting/runelite/plugins/actionprogress/Action.java
+++ b/src/main/java/com/github/calebwhiting/runelite/plugins/actionprogress/Action.java
@@ -37,7 +37,6 @@ public enum Action
 	FLETCH_CUT_CROSSBOW("Cutting", ActionProgressConfig::fletchCrossbows, ActionIcon.SPRITE_FLETCHING, 2, 3),
 	FLETCH_ATTACH_CROSSBOW("Attaching", ActionProgressConfig::fletchCrossbows, ActionIcon.SPRITE_FLETCHING, 2),
 	FLETCH_STRING_CROSSBOW("Stringing", ActionProgressConfig::fletchCrossbows, ActionIcon.SPRITE_FLETCHING, 2),
-	FLETCH_JAVELIN_1Tick("Attaching", ActionProgressConfig::fletchJavelin, ActionIcon.SPRITE_FLETCHING, 1),
 	FLETCH_JAVELIN_2Tick("Attaching", ActionProgressConfig::fletchJavelin, ActionIcon.SPRITE_FLETCHING, 2),
 	FLETCH_DART("Attaching", ActionProgressConfig::fletchArrowsAndBolts, ActionIcon.SPRITE_FLETCHING, 2),
 	GRIND("Grinding", ActionProgressConfig::grinding, ActionIcon.SPRITE_TOTAL, 0, 2, 3),

--- a/src/main/java/com/github/calebwhiting/runelite/plugins/actionprogress/Action.java
+++ b/src/main/java/com/github/calebwhiting/runelite/plugins/actionprogress/Action.java
@@ -37,7 +37,7 @@ public enum Action
 	FLETCH_CUT_CROSSBOW("Cutting", ActionProgressConfig::fletchCrossbows, ActionIcon.SPRITE_FLETCHING, 2, 3),
 	FLETCH_ATTACH_CROSSBOW("Attaching", ActionProgressConfig::fletchCrossbows, ActionIcon.SPRITE_FLETCHING, 2),
 	FLETCH_STRING_CROSSBOW("Stringing", ActionProgressConfig::fletchCrossbows, ActionIcon.SPRITE_FLETCHING, 2),
-	FLETCH_JAVELIN_2Tick("Attaching", ActionProgressConfig::fletchJavelin, ActionIcon.SPRITE_FLETCHING, 2),
+	FLETCH_JAVELIN("Attaching", ActionProgressConfig::fletchJavelin, ActionIcon.SPRITE_FLETCHING, 2),
 	FLETCH_DART("Attaching", ActionProgressConfig::fletchArrowsAndBolts, ActionIcon.SPRITE_FLETCHING, 2),
 	GRIND("Grinding", ActionProgressConfig::grinding, ActionIcon.SPRITE_TOTAL, 0, 2, 3),
 	HERB_CLEAN("Cleaning", ActionProgressConfig::herbCleaning, ActionIcon.SPRITE_HERBLORE, 0, 2),

--- a/src/main/java/com/github/calebwhiting/runelite/plugins/actionprogress/detect/ChatboxDetector.java
+++ b/src/main/java/com/github/calebwhiting/runelite/plugins/actionprogress/detect/ChatboxDetector.java
@@ -278,7 +278,7 @@ public class ChatboxDetector extends ActionDetector
 		 */
 		this.registerAction(FLETCH_ATTACH, Fletching.UNENCHANTED_BOLTS_AND_ARROWS);
 		this.registerAction(FLETCH_ATTACH, HEADLESS_ARROW, FLIGHTED_OGRE_ARROW, AMETHYST_BROAD_BOLTS, AMETHYST_ARROW);
-		this.registerAction(FLETCH_JAVELIN_2Tick, Fletching.JAVELINS);
+		this.registerAction(FLETCH_JAVELIN, Fletching.JAVELINS);
 		this.registerAction(FLETCH_CUT_ARROW_SHAFT, ARROW_SHAFT, BRUMA_KINDLING, OGRE_ARROW_SHAFT);
 		this.registerAction(FLETCH_CUT_TIPS, Fletching.BOLT_TIPS);
 		/*

--- a/src/main/java/com/github/calebwhiting/runelite/plugins/actionprogress/detect/ChatboxDetector.java
+++ b/src/main/java/com/github/calebwhiting/runelite/plugins/actionprogress/detect/ChatboxDetector.java
@@ -278,8 +278,7 @@ public class ChatboxDetector extends ActionDetector
 		 */
 		this.registerAction(FLETCH_ATTACH, Fletching.UNENCHANTED_BOLTS_AND_ARROWS);
 		this.registerAction(FLETCH_ATTACH, HEADLESS_ARROW, FLIGHTED_OGRE_ARROW, AMETHYST_BROAD_BOLTS, AMETHYST_ARROW);
-		this.registerAction(FLETCH_JAVELIN_1Tick, Fletching.JAVELINS);
-		this.registerAction(FLETCH_JAVELIN_2Tick, IRON_JAVELIN, MITHRIL_JAVELIN);
+		this.registerAction(FLETCH_JAVELIN_2Tick, Fletching.JAVELINS);
 		this.registerAction(FLETCH_CUT_ARROW_SHAFT, ARROW_SHAFT, BRUMA_KINDLING, OGRE_ARROW_SHAFT);
 		this.registerAction(FLETCH_CUT_TIPS, Fletching.BOLT_TIPS);
 		/*


### PR DESCRIPTION
The wiki lists most of the javelins as 1-tick creation, but all that I tested in game (bronze, steel, addy, rune) were actually 2-tick. 

This PR moves all of the javelins to be 2-tick. 