### PR TITLE
Dev environment clean herbs fix

### DIFF
--- a/src/main/java/com/github/calebwhiting/runelite/plugins/actionprogress/detect/ItemClickDetector.java
+++ b/src/main/java/com/github/calebwhiting/runelite/plugins/actionprogress/detect/ItemClickDetector.java
@@ -34,23 +34,17 @@ public class ItemClickDetector extends ActionDetector
 		if (evt.getMenuAction() != MenuAction.CC_OP) {
 			return;
 		}
-		if (evt.getParam1() != InterfaceID.INVENTORY) {
-			return;
-		}
+		int itemID = evt.getItemId();
 		ItemContainer inventory = this.client.getItemContainer(InventoryID.INVENTORY);
-		if (inventory == null) {
+		if (inventory == null || !inventory.contains(itemID)) {
 			return;
 		}
-		Item item = inventory.getItem(evt.getParam0());
-		if (item == null) {
-			return;
-		}
-		Action action = (Action) this.itemActions.get(item.getId());
+		Action action = this.itemActions.get(itemID);
 		if (action == null) {
 			return;
 		}
-		int amount = this.inventoryManager.getItemCountById(item.getId());
-		this.actionManager.setAction(action, amount, item.getId());
+		int amount = this.inventoryManager.getItemCountById(itemID);
+		this.actionManager.setAction(action, amount, itemID);
 	}
 
 }


### PR DESCRIPTION
Cleaning herbs wasn't working at all in the dev environment. I did confirm that it does still work in the current runelite-release version though. 

I modified the logic which got it back to working in dev, and should also still work in prod. It's also a bit simpler since the itemID comes off the event itself.