### PR TITLE
Readjusting math logic for the smithing outfit.

### DIFF
--- a/src/main/java/com/github/calebwhiting/runelite/plugins/actionprogress/ActionManager.java
+++ b/src/main/java/com/github/calebwhiting/runelite/plugins/actionprogress/ActionManager.java
@@ -64,7 +64,7 @@ public class ActionManager
 		int nTicksElapsed = 0;
 		int[] timings = action.getTickTimes();
 		//Could be done more cleanly elsewhere, but it would require changing everything from int to double
-		int realActionCount = action == Action.SMITHING_WITH_SMITH_OUTFIT ? actionCount / 2 : actionCount; 
+		int realActionCount = action == Action.SMITHING_WITH_SMITH_OUTFIT ? (int) (actionCount * .8) : actionCount;
 		for (int i = 0; i < realActionCount; i++) {
 			nTicksElapsed += timings[i >= timings.length ? timings.length - 1 : i];
 		}


### PR DESCRIPTION
The original logic was halfing the action count. Smithing outfit drops the tick to 4 from 5 so it saves 20% of the time not 50. Not clean as you said because realActionCount is not a double but it lines up a lot nicer than before.