### PR TITLE
Plank Make Fixes: enhances target detection, fixes widget

### DIFF
--- a/src/main/java/com/github/calebwhiting/runelite/plugins/actionprogress/detect/PlankMakeSpellDetector.java
+++ b/src/main/java/com/github/calebwhiting/runelite/plugins/actionprogress/detect/PlankMakeSpellDetector.java
@@ -36,10 +36,13 @@ public class PlankMakeSpellDetector extends ActionDetector
 		if (inventory == null) {
 			return;
 		}
+		if (!evt.getMenuTarget().contains("<col=00ff00>Plank Make</col><col=ffffff> ->")) {
+			return;
+		}
 		for (Magic.PlankMakeSpell plankMakeSpell : Magic.PlankMakeSpell.values()) {
 			Magic.Spell spell = plankMakeSpell.getSpell();
 			Widget widget = this.client.getWidget(spell.getWidgetId());
-			if (widget == null || widget.getBorderType() != 0) {
+			if (widget == null || widget.getBorderType() != 2) {
 				continue;
 			}
 			int itemId = evt.getItemId();


### PR DESCRIPTION
1. Ensures that plank make is detected only when casting the spell. (Instead of widget on widget). 
2. Correct widget border type for casting plank make


Fixes: 
* https://github.com/guillaume009/runelite-plugin-action-progress/issues/61
* https://github.com/guillaume009/runelite-plugin-action-progress/issues/58

Screenshot: 

https://i.imgur.com/DSGkdWO.gif

Sidenote: 

This is my first time working on a runelite plugin. I'm not 100% sure if this is the best way to do border detection. 