### PR TITLE
Added support for charged Bryophyta's staff to provide nature runes

### DIFF
--- a/src/main/java/com/github/calebwhiting/runelite/data/Magic.java
+++ b/src/main/java/com/github/calebwhiting/runelite/data/Magic.java
@@ -768,7 +768,7 @@ public interface Magic
 		COSMIC("Cosmic", RuneIDs.COSMIC.build()),
 		CHAOS("Chaos", RuneIDs.CHAOS.build()),
 		ASTRAL("Astral", RuneIDs.ASTRAL.build()),
-		NATURE("Nature", RuneIDs.NATURE.build()),
+		NATURE("Nature", RuneIDs.NATURE.build(), new IDs(StaveIDs.NATURE).build()),
 		LAW("Law", RuneIDs.LAW.build()),
 		DEATH("Death", RuneIDs.DEATH.build()),
 		BLOOD("Blood", RuneIDs.BLOOD.build()),
@@ -931,7 +931,9 @@ public interface Magic
 
 	interface StaveIDs
 	{
-
+		IDs NATURE = new IDs(
+				net.runelite.api.gameval.ItemID.NATURE_STAFF_CHARGED
+		);
 		IDs SMOKE = new IDs(
 				ItemID.SMOKE_BATTLESTAFF,
 				ItemID.MYSTIC_SMOKE_STAFF


### PR DESCRIPTION
The code is quite simple we just need to add the charged bryo staff as being able to provide nature runes when it is equipped.

The only problem is that I don't have the staff to confirm this is functional. It seems extremely straightforward though.

_I need someone to test this @guillaume009 because I don't have a bryo staff on my ironman!_

If this works with plank make then this fixes #140 