### PR TITLE
Fix ItemID.DESERT_GOAT_HORN compile break causing plugin incompatibility

### DIFF
--- a/src/main/java/com/github/calebwhiting/runelite/plugins/actionprogress/detect/UseItemOnItemDetector.java
+++ b/src/main/java/com/github/calebwhiting/runelite/plugins/actionprogress/detect/UseItemOnItemDetector.java
@@ -32,7 +32,7 @@ public class UseItemOnItemDetector extends ActionDetector
 			new Product(GRIND, 				GROUND_CHARCOAL, 				new Ingredient[]{ new Ingredient(CHARCOAL)}, 													PESTLE_AND_MORTAR),
 			new Product(GRIND, 				CHOCOLATE_DUST, 				new Ingredient[]{ new Ingredient(CHOCOLATE_BAR)}, 												PESTLE_AND_MORTAR),
 			new Product(GRIND, 				GROUND_GIANT_CRAB_MEAT, 		new Ingredient[]{ new Ingredient(GIANT_CRAB_MEAT)}, 													PESTLE_AND_MORTAR),
-			new Product(GRIND, 				GOAT_HORN_DUST, 				new Ingredient[]{ new Ingredient(DESERT_GOAT_HORN)}, 											PESTLE_AND_MORTAR),
+			new Product(GRIND, 				GOAT_HORN_DUST, 				new Ingredient[]{ new Ingredient(GOAT_HORN)}, 											PESTLE_AND_MORTAR),
 			new Product(GRIND, 				GROUND_THISTLE, 				new Ingredient[]{ new Ingredient(DRIED_THISTLE)}, 												PESTLE_AND_MORTAR),
 			new Product(GRIND, 				GORAK_CLAW_POWDER, 				new Ingredient[]{ new Ingredient(GORAK_CLAWS)}, 												PESTLE_AND_MORTAR),
 			new Product(GRIND, 				GROUND_GUAM, 					new Ingredient[]{ new Ingredient(GUAM_LEAF)}, 													PESTLE_AND_MORTAR),


### PR DESCRIPTION
## Summary
RuneLite's `ItemID` no longer has a `DESERT_GOAT_HORN` constant (deduped into the regular `GOAT_HORN` id), so the plugin fails to compile against the current client API. This is what causes RuneLite to report the plugin as "incompatible, requires update by its author".

Fixes #177

## Test plan
- `./gradlew compileJava` — now succeeds against the current RuneLite client (previously failed with `cannot find symbol: DESERT_GOAT_HORN`)
- `./gradlew test` — passes