### PR TITLE
Recognize Twinflame staff as an unlimited fire/water rune source

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok:1.18.20'
 
 	testImplementation 'junit:junit:4.13.1'
+	testImplementation 'org.jetbrains:annotations:24.1.0'
 
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
 	testImplementation group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/com/github/calebwhiting/runelite/data/Magic.java
+++ b/src/main/java/com/github/calebwhiting/runelite/data/Magic.java
@@ -1299,7 +1299,8 @@ public interface Magic
 				STEAM,
 				ItemID.STAFF_OF_WATER,
 				ItemID.WATER_BATTLESTAFF,
-				ItemID.MYSTIC_WATER_STAFF
+				ItemID.MYSTIC_WATER_STAFF,
+				ItemID.TWINFLAME_STAFF
 		);
 		IDs EARTH = new IDs(
 				DUST,
@@ -1310,12 +1311,13 @@ public interface Magic
 				ItemID.MYSTIC_EARTH_STAFF
 		);
 		IDs FIRE = new IDs(
-				SMOKE, 
-				STEAM, 
-				LAVA, 
-				ItemID.STAFF_OF_FIRE, 
+				SMOKE,
+				STEAM,
+				LAVA,
+				ItemID.STAFF_OF_FIRE,
 				ItemID.FIRE_BATTLESTAFF,
-				ItemID.MYSTIC_FIRE_STAFF
+				ItemID.MYSTIC_FIRE_STAFF,
+				ItemID.TWINFLAME_STAFF
 		);
 
 	}


### PR DESCRIPTION
## Summary
- Fixes #172. The Twinflame staff (item 30634) is an infinite source of both fire and water runes (like the battlestaves/tomes it's built from), but it wasn't listed in `StaveIDs.FIRE`/`StaveIDs.WATER` in `Magic.java`.
- Without it, `Rune.FIRE.countAvailable()`/`Rune.WATER.countAvailable()` fall through to counting loose runes in inventory/rune pouch. A player relying on the staff (no loose fire/water runes) gets 0 available casts for any spell needing both, e.g. Bake Pie (4 fire + 1 astral + 4 water) — so `BakePieSpellDetector` tracks the action with `amount=0` and the progress bar breaks. This matches the behavior reported in #172 and clears up when switching to a Water staff/Tome of fire, which are already recognized.
- Also includes a small unrelated fix: `build.gradle` was missing the `org.jetbrains:annotations` test dependency that `IDQuery.java` needs for its `@Language` annotation, so `./gradlew test` couldn't even compile on a clean checkout of `main`. Added it so this fix (and future ones) can actually be verified with the test suite.

## Test plan
- `./gradlew compileJava` — succeeds
- `./gradlew test` — succeeds (`DataVerifyTest` passes; its stderr warnings about unrelated stale constants are pre-existing and unaffected by this change)