### PR TITLE
Count planks stored in the plank sack for recipe availability

### DIFF
--- a/src/main/java/com/github/calebwhiting/runelite/api/InventoryManager.java
+++ b/src/main/java/com/github/calebwhiting/runelite/api/InventoryManager.java
@@ -5,10 +5,12 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import net.runelite.api.*;
 import net.runelite.api.events.MenuOptionClicked;
+import net.runelite.api.gameval.VarbitID;
 import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
 
 import java.util.Arrays;
+import java.util.Map;
 import java.util.function.IntPredicate;
 import java.util.stream.Stream;
 
@@ -19,6 +21,23 @@ public class InventoryManager
 	@Inject private Client client;
 
 	@Inject private EventBus eventBus;
+
+	// The plank sack (like the rune pouch) supplies its contents to actions without the planks
+	// ever entering the inventory, so item-count lookups need to add its contents in as well.
+	private static final int[] PLANK_SACK_ITEM_IDS = {
+			ItemID.PLANK_SACK,
+			ItemID.PLANK_SACK_25629
+	};
+
+	private static final Map<Integer, Integer> PLANK_SACK_VARBITS_BY_PLANK_ID = Map.of(
+			ItemID.PLANK, VarbitID.PLANK_SACK_PLAIN,
+			ItemID.OAK_PLANK, VarbitID.PLANK_SACK_OAK,
+			ItemID.TEAK_PLANK, VarbitID.PLANK_SACK_TEAK,
+			ItemID.MAHOGANY_PLANK, VarbitID.PLANK_SACK_MAHOGANY,
+			ItemID.CAMPHOR_PLANK, VarbitID.PLANK_SACK_CAMPHOR,
+			ItemID.IRONWOOD_PLANK, VarbitID.PLANK_SACK_IRONWOOD,
+			ItemID.ROSEWOOD_PLANK, VarbitID.PLANK_SACK_ROSEWOOD
+	);
 
 	@Subscribe
 	public void onMenuOptionClicked(MenuOptionClicked evt)
@@ -70,7 +89,26 @@ public class InventoryManager
 		}
 		int[] copy = ids.clone();
 		Arrays.sort(copy);
-		return this.getItemCount(id -> Arrays.binarySearch(copy, id) >= 0);
+		int count = this.getItemCount(id -> Arrays.binarySearch(copy, id) >= 0);
+		for (int id : Arrays.stream(copy).distinct().toArray()) {
+			count += this.getPlankSackCount(id);
+		}
+		return count;
+	}
+
+	private int getPlankSackCount(int plankItemId)
+	{
+		Integer varbitId = PLANK_SACK_VARBITS_BY_PLANK_ID.get(plankItemId);
+		if (varbitId == null) {
+			return 0;
+		}
+		boolean carryingSack = this.getItems()
+				.mapToInt(Item::getId)
+				.anyMatch(id -> Arrays.stream(PLANK_SACK_ITEM_IDS).anyMatch(sackId -> sackId == id));
+		if (!carryingSack) {
+			return 0;
+		}
+		return this.client.getVarbitValue(varbitId);
 	}
 
 }


### PR DESCRIPTION
## Summary
Fixes #167. `InventoryManager.getItemCountById()` (used by `Recipe.getMakeProductCount()` for every recipe-based action, including the hull/repair-kit recipes in `ChatboxDetector`) only ever looked at loose planks in the inventory ItemContainer. It had no awareness of the plank sack, which — like the rune pouch already handled in `Magic.Rune.countAvailable()` — feeds its stored planks directly into actions without them entering the inventory.

So building hulls (or repair kits) at a Shipwright's workbench tracked correctly only until the loose inventory planks ran out; the sack's remaining planks were invisible to the plugin, and the action bar stopped counting the rest of the action even though the client kept pulling planks from the sack and completing it — matching the reported behavior exactly.

Each plank type has its own varbit (`VarbitID.PLANK_SACK_PLAIN/OAK/TEAK/MAHOGANY/CAMPHOR/IRONWOOD/ROSEWOOD`) tracking how many of that type are currently stored. `getItemCountById()` now adds the sack's count for any plank-type ID being queried, but only when the sack itself is being carried (so a plank sack sitting in the bank doesn't count).

## Test plan
- `./gradlew compileJava` — succeeds
- `./gradlew test` — succeeds