### PR TITLE
Fix jewellery enchanting never triggering the progress bar

### DIFF
--- a/src/main/java/com/github/calebwhiting/runelite/plugins/actionprogress/detect/EnchantSpellDetector.java
+++ b/src/main/java/com/github/calebwhiting/runelite/plugins/actionprogress/detect/EnchantSpellDetector.java
@@ -38,7 +38,7 @@ public class EnchantSpellDetector extends ActionDetector
 			for (Magic.EnchantSpell enchantSpell : Magic.EnchantSpell.values()) {
 				Magic.Spell spell = enchantSpell.getSpell();
 				Widget widget = this.client.getWidget(spell.getWidgetId());
-				if (widget != null && widget.getBorderType() == 2) {
+				if (widget != null && widget.getBorderType() == 0) {
 					int itemId = evt.getItemId();
 					if (Arrays.binarySearch(enchantSpell.getJewellery(), itemId) < 0) {
 						continue;


### PR DESCRIPTION
## Summary
Fixes #165. Fixes #166.

`EnchantSpellDetector` required `widget.getBorderType() == 2` to consider an enchant spell "selected" before matching it against the clicked item. On the current client, the selected spell's widget consistently reports `borderType == 0`, never `2` — so the loop never found a match and `setAction()` was never called, for any jewellery tier. This explains why every reported case (sapphire rings, topaz/opal bracelets, ruby necklaces) showed the exact same symptom: no progress bar, no notification, nothing.

## Verification
This was verified live, not guessed:
- Built and ran a local dev client (`gradle run`) against a real account, with temporary tick-level logging added to confirm both the widget-ID computation and the item-ID matching were already correct — only the border-type value was wrong.
- Confirmed the fix by casting Lvl-3 Enchant on ruby jewellery (rings, necklaces, bracelets) in batches of 2, 5, and 11, watching the progress bar track correctly through to the final cast each time.
- Also checked whether the existing tick-timing model (`Action.MAGIC_ENCHANT_JEWELLERY`'s `0, 7` tick values) needed adjusting, since it had never been observable before (the bar never appeared to test against). A larger, uninterrupted sample confirmed the original `0, 7` values are accurate — left untouched.

## Test plan
- `./gradlew compileJava` — succeeds
- `./gradlew test` — succeeds